### PR TITLE
feat(keyFunc): add `WithHTTPKeyFunc`, `WithGRPCKeyFunc` options

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,9 @@ jobs:
 
       - run: go vet ./...
 
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v9.2.0
+
       - run: go test -race -coverprofile=coverage.out ./...
 
       - uses: actions/upload-artifact@v4

--- a/benchmark/bench_test.go
+++ b/benchmark/bench_test.go
@@ -23,7 +23,7 @@ func BenchmarkRoundTripNoHedge(b *testing.B) {
 	for i := 0; i < 25; i++ {
 		req, _ := http.NewRequestWithContext(context.Background(), "GET", srv.URL, nil)
 		resp, _ := tr.RoundTrip(req)
-		resp.Body.Close()
+		_ = resp.Body.Close()
 	}
 
 	b.ResetTimer()
@@ -32,7 +32,7 @@ func BenchmarkRoundTripNoHedge(b *testing.B) {
 			req, _ := http.NewRequestWithContext(context.Background(), "GET", srv.URL, nil)
 			resp, err := tr.RoundTrip(req)
 			if err == nil {
-				resp.Body.Close()
+				_ = resp.Body.Close()
 			}
 		}
 	})
@@ -57,7 +57,7 @@ func BenchmarkRoundTripWithHedge(b *testing.B) {
 	for i := 0; i < 25; i++ {
 		req, _ := http.NewRequestWithContext(context.Background(), "GET", srv.URL, nil)
 		resp, _ := tr.RoundTrip(req)
-		resp.Body.Close()
+		_ = resp.Body.Close()
 	}
 
 	b.ResetTimer()
@@ -65,7 +65,7 @@ func BenchmarkRoundTripWithHedge(b *testing.B) {
 		req, _ := http.NewRequestWithContext(context.Background(), "GET", srv.URL, nil)
 		resp, err := tr.RoundTrip(req)
 		if err == nil {
-			resp.Body.Close()
+			_ = resp.Body.Close()
 		}
 	}
 }

--- a/hedge.go
+++ b/hedge.go
@@ -48,13 +48,13 @@ func New(transport http.RoundTripper, opts ...Option) http.RoundTripper {
 	}
 }
 
-func (t *hedgedTransport) sketchFor(host string) *sketch.WindowedSketch {
-	v, ok := t.sketches.Load(host)
+func (t *hedgedTransport) sketchFor(key string) *sketch.WindowedSketch {
+	v, ok := t.sketches.Load(key)
 	if ok {
 		return v.(*sketch.WindowedSketch)
 	}
 	s := sketch.NewWindowedSketch(0.01, t.cfg.windowDuration)
-	actual, loaded := t.sketches.LoadOrStore(host, s)
+	actual, loaded := t.sketches.LoadOrStore(key, s)
 	if loaded {
 		s.Stop()
 		return actual.(*sketch.WindowedSketch)
@@ -76,7 +76,7 @@ func (t *hedgedTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	t.stats.TotalRequests.Add(1)
 
 	host := req.URL.Host
-	sk := t.sketchFor(host)
+	sk := t.sketchFor(t.cfg.httpKeyFunc(req))
 	counter := t.counterFor(host)
 	n := counter.Add(1)
 
@@ -189,19 +189,19 @@ func drainLoser(ch <-chan result) {
 	if !ok || res.resp == nil {
 		return
 	}
-	io.Copy(io.Discard, io.LimitReader(res.resp.Body, drainLimit))
-	res.resp.Body.Close()
+	_, _ = io.Copy(io.Discard, io.LimitReader(res.resp.Body, drainLimit))
+	_ = res.resp.Body.Close()
 }
 
 // LatencyEstimate returns the current hedge-delay threshold the transport
-// would use for the given host and quantile. Returns 0 if rt was not
-// created by New.
-func LatencyEstimate(rt http.RoundTripper, host string, q float64) time.Duration {
+// would use for the given key (generally hostname) and quantile. Returns 0
+// if rt was not created by New.
+func LatencyEstimate(rt http.RoundTripper, key string, q float64) time.Duration {
 	ht, ok := rt.(*hedgedTransport)
 	if !ok {
 		return 0
 	}
-	sk := ht.sketchFor(host)
+	sk := ht.sketchFor(key)
 	est := sk.Quantile(q)
 	if math.IsNaN(est) || est <= 0 {
 		return ht.cfg.warmupDelay

--- a/hedge_grpc.go
+++ b/hedge_grpc.go
@@ -27,6 +27,12 @@ type grpcResult struct {
 	primary bool
 }
 
+type GRPCRequestData struct {
+	Hostname string
+	Method   string
+	Request  any
+}
+
 func NewUnaryClientInterceptor(opts ...Option) grpc.UnaryClientInterceptor {
 	cfg := defaults()
 	for _, o := range opts {
@@ -44,13 +50,13 @@ func NewUnaryClientInterceptor(opts ...Option) grpc.UnaryClientInterceptor {
 	return gi.intercept
 }
 
-func (gi *grpcInterceptor) sketchFor(target string) *sketch.WindowedSketch {
-	v, ok := gi.sketches.Load(target)
+func (gi *grpcInterceptor) sketchFor(key string) *sketch.WindowedSketch {
+	v, ok := gi.sketches.Load(key)
 	if ok {
 		return v.(*sketch.WindowedSketch)
 	}
 	s := sketch.NewWindowedSketch(0.01, gi.cfg.windowDuration)
-	actual, loaded := gi.sketches.LoadOrStore(target, s)
+	actual, loaded := gi.sketches.LoadOrStore(key, s)
 	if loaded {
 		s.Stop()
 		return actual.(*sketch.WindowedSketch)
@@ -80,7 +86,11 @@ func (gi *grpcInterceptor) intercept(ctx context.Context, method string, req, re
 	gi.stats.TotalRequests.Add(1)
 
 	target := cc.Target()
-	sk := gi.sketchFor(target)
+	sk := gi.sketchFor(gi.cfg.grpcKeyFunc(GRPCRequestData{
+		Hostname: target,
+		Method:   method,
+		Request:  req,
+	}))
 	counter := gi.counterFor(target)
 	n := counter.Add(1)
 

--- a/hedge_grpc_test.go
+++ b/hedge_grpc_test.go
@@ -2,6 +2,7 @@ package hedge
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -17,7 +18,7 @@ func newTestConn(t *testing.T) *grpc.ClientConn {
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() { cc.Close() })
+	t.Cleanup(func() { _ = cc.Close() })
 	return cc
 }
 
@@ -81,6 +82,85 @@ func TestGRPCHedgeWhenSlow(t *testing.T) {
 	}
 	if n := stats.HedgedRequests.Load(); n == 0 {
 		t.Error("expected HedgedRequests > 0")
+	}
+}
+
+func TestGRPCHedgePerKey(t *testing.T) {
+	var stats *Stats
+	interceptor := NewUnaryClientInterceptor(
+		WithStats(&stats),
+		WithPercentile(0.5),
+		WithBudgetPercent(100),
+		WithMinDelay(10*time.Millisecond),
+		WithGRPCKeyFunc(func(d GRPCRequestData) string {
+			return fmt.Sprintf("%s/%s", d.Hostname, d.Method)
+		}),
+	)
+	cc := newTestConn(t)
+	fooDelay := 5 * time.Millisecond
+	barDelay := 20 * time.Millisecond
+	invoker := func(ctx context.Context, method string, _, _ interface{}, _ *grpc.ClientConn, _ ...grpc.CallOption) error {
+		var delay time.Duration
+
+		switch method {
+		case "/test.Svc/Foo":
+			delay = fooDelay
+		case "/test.Svc/Bar":
+			delay = barDelay
+		default:
+			return nil
+		}
+		select {
+		case <-time.After(delay):
+			return nil
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+
+	// warm up both keys
+	for i := 0; i < 25; i++ {
+		if err := interceptor(context.Background(), "/test.Svc/Foo", &testMsg{}, &testMsg{}, cc, invoker); err != nil {
+			t.Fatalf("foo warmup %d: %v", i, err)
+		}
+		if err := interceptor(context.Background(), "/test.Svc/Bar", &testMsg{}, &testMsg{}, cc, invoker); err != nil {
+			t.Fatalf("bar warmup %d: %v", i, err)
+		}
+	}
+
+	*stats = Stats{} // reset stats after warmup
+
+	if err := interceptor(context.Background(), "/test.Svc/Foo", &testMsg{}, &testMsg{}, cc, invoker); err != nil {
+		t.Fatal(err)
+	}
+	if n := stats.HedgedRequests.Load(); n != 0 {
+		t.Errorf("HedgedRequests = %d for fast /test.Svc/Foo, want 0", n)
+	}
+
+	if err := interceptor(context.Background(), "/test.Svc/Bar", &testMsg{}, &testMsg{}, cc, invoker); err != nil {
+		t.Fatal(err)
+	}
+	if n := stats.HedgedRequests.Load(); n != 0 {
+		t.Errorf("HedgedRequests = %d for fast /test.Svc/Bar, want 0", n)
+	}
+
+	// swap foo and bar response delays
+	fooDelay, barDelay = barDelay, fooDelay
+
+	// bar requests should not hedge because they got faster
+	if err := interceptor(context.Background(), "/test.Svc/Bar", &testMsg{}, &testMsg{}, cc, invoker); err != nil {
+		t.Fatal(err)
+	}
+	if n := stats.HedgedRequests.Load(); n != 0 {
+		t.Errorf("HedgedRequests = %d for /test.Svc/Bar, want 0", n)
+	}
+
+	// foo requests should hedge because they are slower than before
+	if err := interceptor(context.Background(), "/test.Svc/Foo", &testMsg{}, &testMsg{}, cc, invoker); err != nil {
+		t.Fatal(err)
+	}
+	if n := stats.HedgedRequests.Load(); n == 0 {
+		t.Error("expected HedgedRequests > 0 for slowed down /test.Svc/Foo")
 	}
 }
 

--- a/hedge_test.go
+++ b/hedge_test.go
@@ -2,6 +2,7 @@ package hedge
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -40,12 +41,12 @@ func newTransport(t *testing.T, opts ...Option) (http.RoundTripper, *Stats) {
 func warmup(t *testing.T, tr http.RoundTripper, url string, n int) {
 	t.Helper()
 	for i := 0; i < n; i++ {
-		req, _ := http.NewRequest("GET", url, nil)
+		req := httptest.NewRequest("GET", url, nil)
 		resp, err := tr.RoundTrip(req)
 		if err != nil {
 			t.Fatalf("warmup request %d failed: %v", i, err)
 		}
-		resp.Body.Close()
+		_ = resp.Body.Close()
 	}
 }
 
@@ -61,12 +62,12 @@ func TestNoHedgeWhenFast(t *testing.T) {
 	)
 	warmup(t, tr, srv.URL, 25)
 
-	req, _ := http.NewRequest("GET", srv.URL, nil)
+	req := httptest.NewRequest("GET", srv.URL, nil)
 	resp, err := tr.RoundTrip(req)
 	if err != nil {
 		t.Fatal(err)
 	}
-	resp.Body.Close()
+	_ = resp.Body.Close()
 
 	if n := stats.HedgedRequests.Load(); n != 0 {
 		t.Errorf("HedgedRequests = %d, want 0", n)
@@ -89,12 +90,12 @@ func TestHedgeWhenSlow(t *testing.T) {
 	// now slow
 	delay.Store(int64(200 * time.Millisecond))
 
-	req, _ := http.NewRequest("GET", srv.URL, nil)
+	req := httptest.NewRequest("GET", srv.URL, nil)
 	resp, err := tr.RoundTrip(req)
 	if err != nil {
 		t.Fatal(err)
 	}
-	resp.Body.Close()
+	_ = resp.Body.Close()
 
 	if n := stats.HedgedRequests.Load(); n == 0 {
 		t.Error("expected HedgedRequests > 0")
@@ -133,12 +134,12 @@ func TestHedgeWins(t *testing.T) {
 	)
 	warmup(t, tr, srv.URL, 25)
 
-	req, _ := http.NewRequest("GET", srv.URL, nil)
+	req := httptest.NewRequest("GET", srv.URL, nil)
 	resp, err := tr.RoundTrip(req)
 	if err != nil {
 		t.Fatal(err)
 	}
-	resp.Body.Close()
+	_ = resp.Body.Close()
 
 	if got := resp.Header.Get("X-Responder"); got != "hedge" {
 		t.Errorf("X-Responder = %q, want hedge", got)
@@ -160,12 +161,12 @@ func TestPrimaryWins(t *testing.T) {
 	)
 	warmup(t, tr, srv.URL, 25)
 
-	req, _ := http.NewRequest("GET", srv.URL, nil)
+	req := httptest.NewRequest("GET", srv.URL, nil)
 	resp, err := tr.RoundTrip(req)
 	if err != nil {
 		t.Fatal(err)
 	}
-	resp.Body.Close()
+	_ = resp.Body.Close()
 
 	if n := stats.HedgedRequests.Load(); n != 0 {
 		t.Errorf("HedgedRequests = %d, want 0", n)
@@ -196,10 +197,10 @@ func TestBudgetExhaustion(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			req, _ := http.NewRequest("GET", srv.URL, nil)
+			req := httptest.NewRequest("GET", srv.URL, nil)
 			resp, err := tr.RoundTrip(req)
 			if err == nil {
-				resp.Body.Close()
+				_ = resp.Body.Close()
 			}
 		}()
 	}
@@ -212,13 +213,6 @@ func TestBudgetExhaustion(t *testing.T) {
 		t.Errorf("HedgedRequests = %d, want < %d (budget should have limited hedges)", hedged, n)
 	}
 }
-
-// bodyReader wraps a string as an io.Reader without triggering http.NewRequest's
-// automatic GetBody injection (which only fires for *bytes.Buffer, *bytes.Reader,
-// and *strings.Reader).
-type bodyReader struct{ r *strings.Reader }
-
-func (b *bodyReader) Read(p []byte) (int, error) { return b.r.Read(p) }
 
 func TestNoHedgeForPOST(t *testing.T) {
 	var delay atomic.Int64
@@ -233,18 +227,14 @@ func TestNoHedgeForPOST(t *testing.T) {
 	)
 	warmup(t, tr, srv.URL, 25)
 
-	req, _ := http.NewRequest("POST", srv.URL, &bodyReader{strings.NewReader("payload")})
-	// GetBody is nil — http.NewRequest won't set it for an unknown io.Reader type
-	if req.GetBody != nil {
-		t.Fatal("test setup error: GetBody should be nil for unknown reader type")
-	}
+	req := httptest.NewRequest("POST", srv.URL, strings.NewReader("payload"))
 
 	before := stats.HedgedRequests.Load()
 	resp, err := tr.RoundTrip(req)
 	if err != nil {
 		t.Fatal(err)
 	}
-	resp.Body.Close()
+	_ = resp.Body.Close()
 
 	if delta := stats.HedgedRequests.Load() - before; delta != 0 {
 		t.Errorf("HedgedRequests delta = %d, want 0 for POST without GetBody", delta)
@@ -265,7 +255,7 @@ func TestHedgeWithGetBody(t *testing.T) {
 	warmup(t, tr, srv.URL, 25)
 
 	payload := "payload"
-	req, _ := http.NewRequest("POST", srv.URL, strings.NewReader(payload))
+	req := httptest.NewRequest("POST", srv.URL, strings.NewReader(payload))
 	req.GetBody = func() (io.ReadCloser, error) {
 		return io.NopCloser(strings.NewReader(payload)), nil
 	}
@@ -274,7 +264,7 @@ func TestHedgeWithGetBody(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	resp.Body.Close()
+	_ = resp.Body.Close()
 
 	if n := stats.HedgedRequests.Load(); n == 0 {
 		t.Error("expected HedgedRequests > 0 for POST with GetBody")
@@ -300,13 +290,13 @@ func TestContextCancellation(t *testing.T) {
 	)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	req, _ := http.NewRequestWithContext(ctx, "GET", srv.URL, nil)
+	req := httptest.NewRequestWithContext(ctx, "GET", srv.URL, nil)
 
 	done := make(chan error, 1)
 	go func() {
 		resp, err := tr.RoundTrip(req)
 		if err == nil {
-			resp.Body.Close()
+			_ = resp.Body.Close()
 		}
 		done <- err
 	}()
@@ -335,12 +325,12 @@ func TestWarmupPhase(t *testing.T) {
 		WithMinDelay(time.Millisecond),
 	)
 
-	req, _ := http.NewRequest("GET", srv.URL, nil)
+	req := httptest.NewRequest("GET", srv.URL, nil)
 	resp, err := tr.RoundTrip(req)
 	if err != nil {
 		t.Fatal(err)
 	}
-	resp.Body.Close()
+	_ = resp.Body.Close()
 
 	if n := stats.WarmupRequests.Load(); n == 0 {
 		t.Error("expected WarmupRequests > 0 during warmup phase")
@@ -348,6 +338,97 @@ func TestWarmupPhase(t *testing.T) {
 	// warmupDelay default is 10ms, backend is 5ms → primary returns before warmup timer
 	if n := stats.HedgedRequests.Load(); n != 0 {
 		t.Errorf("HedgedRequests = %d during warmup, want 0", n)
+	}
+}
+
+func TestHedgePerKey(t *testing.T) {
+	fooDelay := 5 * time.Millisecond
+	barDelay := 20 * time.Millisecond
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /foo", func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-time.After(fooDelay):
+			// continue to respond
+		case <-r.Context().Done():
+			return
+		}
+		w.Header().Set("X-Responder", "foo")
+	})
+	mux.HandleFunc("GET /bar", func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-time.After(barDelay):
+			// continue to respond
+		case <-r.Context().Done():
+			return
+		}
+		w.Header().Set("X-Responder", "bar")
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	tr, stats := newTransport(t,
+		WithBudgetPercent(100),
+		WithMinDelay(time.Millisecond),
+		WithHTTPKeyFunc(func(r *http.Request) string {
+			return fmt.Sprintf("%s %s/%s", r.Method, r.URL.Host, r.URL.Path)
+		}),
+	)
+
+	fooURL := fmt.Sprintf("%s/foo", srv.URL)
+	barURL := fmt.Sprintf("%s/bar", srv.URL)
+	warmup(t, tr, fooURL, 25)
+	warmup(t, tr, barURL, 25)
+
+	*stats = Stats{} // reset stats after warmup
+
+	req := httptest.NewRequest("GET", fooURL, nil)
+	resp, err := tr.RoundTrip(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+
+	if n := stats.HedgedRequests.Load(); n != 0 {
+		t.Errorf("HedgedRequests = %d for fast /foo, want 0", n)
+	}
+
+	req = httptest.NewRequest("GET", barURL, nil)
+	resp, err = tr.RoundTrip(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+
+	if n := stats.HedgedRequests.Load(); n != 0 {
+		t.Errorf("HedgedRequests = %d for slow /bar, want 0", n)
+	}
+
+	// swap foo and bar response delays
+	fooDelay, barDelay = barDelay, fooDelay
+
+	// bar requests should not hedge because they got faster
+	req = httptest.NewRequest("GET", barURL, nil)
+	resp, err = tr.RoundTrip(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+
+	if n := stats.HedgedRequests.Load(); n != 0 {
+		t.Errorf("HedgedRequests = %d for sped up /bar, want 0", n)
+	}
+
+	// foo requests should hedge because they are slower than before
+	req = httptest.NewRequest("GET", fooURL, nil)
+	resp, err = tr.RoundTrip(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+
+	if n := stats.HedgedRequests.Load(); n == 0 {
+		t.Error("expected HedgedRequests > 0 for slowed down /foo")
 	}
 }
 
@@ -370,10 +451,10 @@ func TestConcurrent(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			req, _ := http.NewRequest("GET", srv.URL, nil)
+			req := httptest.NewRequest("GET", srv.URL, nil)
 			resp, err := tr.RoundTrip(req)
 			if err == nil {
-				resp.Body.Close()
+				_ = resp.Body.Close()
 			}
 		}()
 	}
@@ -398,12 +479,12 @@ func TestStats(t *testing.T) {
 	)
 	warmup(t, tr, srv.URL, 25)
 
-	req, _ := http.NewRequest("GET", srv.URL, nil)
+	req := httptest.NewRequest("GET", srv.URL, nil)
 	resp, err := tr.RoundTrip(req)
 	if err != nil {
 		t.Fatal(err)
 	}
-	resp.Body.Close()
+	_ = resp.Body.Close()
 
 	snap := stats.Snapshot()
 	if snap.TotalRequests == 0 {
@@ -423,12 +504,12 @@ func TestWithMaxHedges(t *testing.T) {
 	tr, _ := newTransport(t, WithMaxHedges(2))
 	warmup(t, tr, srv.URL, 5)
 	// just verify it builds and runs without panic
-	req, _ := http.NewRequest("GET", srv.URL, nil)
+	req := httptest.NewRequest("GET", srv.URL, nil)
 	resp, err := tr.RoundTrip(req)
 	if err != nil {
 		t.Fatal(err)
 	}
-	resp.Body.Close()
+	_ = resp.Body.Close()
 }
 
 func TestHedgeAllowedForNoBody(t *testing.T) {
@@ -448,13 +529,13 @@ func TestHedgeAllowedForNoBody(t *testing.T) {
 	delay.Store(int64(200 * time.Millisecond))
 
 	// http.NoBody carries no content, so hedging is safe (same as nil body).
-	req, _ := http.NewRequest("POST", srv.URL, http.NoBody)
+	req := httptest.NewRequest("POST", srv.URL, http.NoBody)
 	before := stats.HedgedRequests.Load()
 	resp, err := tr.RoundTrip(req)
 	if err != nil {
 		t.Fatal(err)
 	}
-	resp.Body.Close()
+	_ = resp.Body.Close()
 
 	if delta := stats.HedgedRequests.Load() - before; delta == 0 {
 		t.Error("expected hedge for POST with http.NoBody (no body to re-send)")
@@ -480,7 +561,7 @@ func TestHedgeWithGetBodyReliable(t *testing.T) {
 	delay.Store(int64(200 * time.Millisecond))
 
 	payload := "payload"
-	req, _ := http.NewRequest("POST", srv.URL, strings.NewReader(payload))
+	req := httptest.NewRequest("POST", srv.URL, strings.NewReader(payload))
 	req.GetBody = func() (io.ReadCloser, error) {
 		return io.NopCloser(strings.NewReader(payload)), nil
 	}
@@ -490,7 +571,7 @@ func TestHedgeWithGetBodyReliable(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	resp.Body.Close()
+	_ = resp.Body.Close()
 
 	if delta := stats.HedgedRequests.Load() - before; delta == 0 {
 		t.Error("expected HedgedRequests > 0 for POST with GetBody on slow backend")
@@ -511,7 +592,7 @@ func TestDrainLoserBody(t *testing.T) {
 			}
 		}
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("response body"))
+		_, _ = w.Write([]byte("response body"))
 	}))
 	defer srv.Close()
 
@@ -522,12 +603,12 @@ func TestDrainLoserBody(t *testing.T) {
 	)
 	warmup(t, tr, srv.URL, 25)
 
-	req, _ := http.NewRequest("GET", srv.URL, nil)
+	req := httptest.NewRequest("GET", srv.URL, nil)
 	resp, err := tr.RoundTrip(req)
 	if err != nil {
 		t.Fatal(err)
 	}
-	resp.Body.Close()
+	_ = resp.Body.Close()
 
 	if n := stats.HedgeWins.Load(); n == 0 {
 		t.Error("expected HedgeWins > 0")

--- a/options.go
+++ b/options.go
@@ -1,6 +1,9 @@
 package hedge
 
-import "time"
+import (
+	"net/http"
+	"time"
+)
 
 type config struct {
 	percentile     float64
@@ -11,6 +14,8 @@ type config struct {
 	warmupRequests int
 	warmupDelay    time.Duration
 	windowDuration time.Duration
+	httpKeyFunc    func(*http.Request) string
+	grpcKeyFunc    func(GRPCRequestData) string
 	stats          **Stats
 }
 
@@ -23,6 +28,8 @@ func defaults() config {
 		minDelay:       1 * time.Millisecond,
 		warmupRequests: 20,
 		warmupDelay:    10 * time.Millisecond,
+		httpKeyFunc:    defaultHTTPKeyFunc,
+		grpcKeyFunc:    defaultGRPCKeyFunc,
 		windowDuration: 30 * time.Second,
 	}
 }
@@ -51,4 +58,44 @@ func WithStats(s **Stats) Option {
 
 func WithEstimatedRPS(rps float64) Option {
 	return func(c *config) { c.budgetRPS = rps }
+}
+
+// WithHTTPKeyFunc customizes how HTTP request latency metrics are bucketed.
+// The default is to bucket metrics by hostname (e.g. "example.com").
+//
+// Clients may use this method to group requests into finer-grained buckets,
+// e.g. by factoring in request attributes like method, path, or query
+// parameters.
+//
+// Use this option when latency characteristics vary significantly across
+// different endpoints on the same host, e.g. "POST example.com/api" vs
+// "GET example.com/static".
+func WithHTTPKeyFunc(f func(r *http.Request) string) Option {
+	return func(c *config) {
+		c.httpKeyFunc = f
+	}
+}
+
+func defaultHTTPKeyFunc(r *http.Request) string {
+	return r.URL.Host
+}
+
+// WithGRPCKeyFunc customizes how gRPC request latency metrics are bucketed.
+// The default is to bucket metrics by hostname (e.g. "example.com").
+//
+// Clients may use this method to group requests into finer-grained buckets,
+// e.g. by factoring in gRPC request attributes such as method (RPC) name,
+// or properties of the request object.
+//
+// Use this option when latency characteristics vary significantly across
+// different endpoints on the same host, e.g. "example.com/api.Service/MethodA"
+// vs "example.com/api.Service/MethodB".
+func WithGRPCKeyFunc(f func(d GRPCRequestData) string) Option {
+	return func(c *config) {
+		c.grpcKeyFunc = f
+	}
+}
+
+func defaultGRPCKeyFunc(d GRPCRequestData) string {
+	return d.Hostname
 }


### PR DESCRIPTION
- Add `WithHTTPKeyFunc(*http.Request)` option to customize how HTTP request latency metrics are bucketed.
- Add `WithGRPCKeyFunc(hedge.GRPCRequestData)` option to customize how GRPC request latency metrics are bucketed.
- Add golangci-lint CI step.
- Fix golangci-lint errors.
  - Use `httptest.NewRequest` (which does not set `Request.GetBody`) in tests instead of `http.NewRequest`.
  - Remove now-unnecessary `bodyReader` workaround from tests.
  - Explicitly assign ignored errors to `_`.